### PR TITLE
Add username to downloaded file name

### DIFF
--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -119,7 +119,7 @@ function Toolbar({ user, hidden, setHidden }: IProps) {
         <button
           className={`${buttonClass} ${downloaded ? "text-green-500" : null}`}
           onClick={() => {
-            download();
+            download(user);
             setDownloaded(true);
           }}
         >

--- a/utils/exports.ts
+++ b/utils/exports.ts
@@ -13,9 +13,9 @@ import {
 /**
  * Grab the banner element and download it as a PNG
  */
-export function download() {
+export function download(user: User) {
   getImage(2).then((blob) => {
-    saveAs(blob, "wrapped.png");
+    saveAs(blob, `wrapped_${user.username}.png`);
   });
 }
 

--- a/utils/shortcuts.ts
+++ b/utils/shortcuts.ts
@@ -17,7 +17,7 @@ export const SHORTCUTS = {
     sequence: `${cmdOrCtrl}+s`,
     method: (e, user) => {
       e.preventDefault();
-      download();
+      download(user);
     },
   },
   copyImage: {


### PR DESCRIPTION
Signed-off-by: Ayush P Gupta <ayushpguptaapg@gmail.com>

This PR aims at adding a username to the file downloaded. 
Simply using `wrapped.png` might cause conflicts with two usernames. 
Now, `wrapped_apgapg.png` would be the file name downloaded. This looks more intuitive.