### PR TITLE
fix: get the max contributed day error

### DIFF
--- a/components/contributions.tsx
+++ b/components/contributions.tsx
@@ -21,7 +21,7 @@ const formatDate = (date: string): string => {
 const getMaxDate = (contributions: number[]) => {
   const max = Math.max(...contributions);
   const maxDayIndex = contributions.findIndex((x) => x == max);
-  const maxDate = formatDate(new Date(2021, 0, maxDayIndex).toDateString());
+  const maxDate = formatDate(new Date(2021, 0, maxDayIndex + 1).toDateString());
   const maxDatePosition =
     maxDayIndex > 240 ? "left-2/3" : maxDayIndex > 120 ? "left-1/3" : "left-0";
 


### PR DESCRIPTION
# Summary
If the max contributed day is the first day in the year, its index is 0, so we will get the error result by old code.

``` js
new Date(2021, 0, 0)  // Thu Dec 31 2020 00:00:00
```

![image](https://user-images.githubusercontent.com/17525377/146704437-328d5183-dcc9-4583-b4ec-b0a4bb1d0407.png)

### Test Plan
The parameter `day` of `new Date` is a real date, which is not like a index as the parameter `month`, so we can fix it by format the index to real date.

```js
new Date(2021, 0, 0 + 1)  // Fri Jan 01 2021 00:00:00
```